### PR TITLE
New test cases have been added

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -34,4 +34,87 @@ Spectator.describe Repo do
       expect(repo.rev).to eq("v0.1.1")
     end
   end
+
+  context "no version or commit" do
+    let(:no_version_or_commit) {
+      <<-EOF
+      git: https://github.com/example/repo.git
+      EOF
+    }
+
+    let(:repo) {
+      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(no_version_or_commit))
+    }
+
+    it "should have nil as revision" do
+      expect(repo.rev).to be_nil
+    end
+  end
+
+  context "with tag" do
+    let(:with_tag) {
+      <<-EOF
+      git: https://github.com/example/repo.git
+      version: refs/tags/v1.0.0
+      EOF
+    }
+
+    let(:repo) {
+      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(with_tag))
+    }
+
+    it "should have the tag as revision" do
+      expect(repo.rev).to eq("refs/tags/v1.0.0")
+    end
+  end
+
+  context "only URL" do
+    let(:only_url) {
+      <<-EOF
+      git: https://github.com/example/repo.git
+      EOF
+    }
+
+    let(:repo) {
+      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(only_url))
+    }
+
+    it "should have nil as revision" do
+      expect(repo.rev).to be_nil
+    end
+  end
+
+  context "different commit" do
+    let(:different_commit) {
+      <<-EOF
+      git: https://github.com/example/repo.git
+      version: 0.1.0+git.commit.1234567890abcdef1234567890abcdef12345678
+      EOF
+    }
+
+    let(:repo) {
+      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(different_commit))
+    }
+
+    it "should have the correct commit as revision" do
+      expect(repo.rev).to eq("1234567890abcdef1234567890abcdef12345678")
+    end
+  end
+
+  context "version with prefix" do
+    let(:version_with_prefix) {
+      <<-EOF
+      git: https://github.com/example/repo.git
+      version: v2.0.0
+      EOF
+    }
+
+    let(:repo) {
+      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(version_with_prefix))
+    }
+
+    it "should have the version as revision with the same prefix" do
+      expect(repo.rev).to eq("v2.0.0")
+    end
+  end
 end


### PR DESCRIPTION
7 examples, 4 failures 

Failed examples:

crystal spec spec/repo_spec.cr:49 # Repo no version or commit should have nil as revision
crystal spec spec/repo_spec.cr:66 # Repo with tag should have the tag as revision
crystal spec spec/repo_spec.cr:82 # Repo only URL should have nil as revision
crystal spec spec/repo_spec.cr:116 # Repo version with prefix should have the version as revision with the same prefix