### PR TITLE
specify the repository type in your input data

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-Spectator.describe Repo do
+Spectator.describe Crystal2Nix::Repo do
   context "commit" do
     let(:with_commit) {
       <<-EOF
@@ -9,8 +9,12 @@ Spectator.describe Repo do
       EOF
     }
 
+    let(:shard) {
+      Crystal2Nix::Shard.from_yaml(with_commit)
+    }
+
     let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(with_commit))
+      Crystal2Nix::Repo.new(shard.url, shard.rev, shard.type)
     }
 
     it "should have the commit as revision" do
@@ -26,8 +30,12 @@ Spectator.describe Repo do
       EOF
     }
 
+    let(:shard) {
+      Crystal2Nix::Shard.from_yaml(with_version)
+    }
+
     let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(with_version))
+      Crystal2Nix::Repo.new(shard.url, shard.rev, shard.type)
     }
 
     it "should prefix version references with a v" do
@@ -35,86 +43,43 @@ Spectator.describe Repo do
     end
   end
 
-  context "no version or commit" do
-    let(:no_version_or_commit) {
+  context "http url" do
+    let(:with_http_url) {
       <<-EOF
-      git: https://github.com/example/repo.git
+      http: https://example.com/archive.tar.gz
       EOF
     }
 
-    let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(no_version_or_commit))
+    let(:shard) {
+      Crystal2Nix::Shard.from_yaml(with_http_url)
     }
 
-    it "should have nil as revision" do
-      expect(repo.rev).to be_nil
+    let(:repo) {
+      Crystal2Nix::Repo.new(shard.url, shard.rev, shard.type)
+    }
+
+    it "should have the correct url" do
+      expect(repo.url).to eq("https://example.com/archive.tar.gz")
     end
   end
 
-  context "with tag" do
-    let(:with_tag) {
-      <<-EOF
-      git: https://github.com/example/repo.git
-      version: refs/tags/v1.0.0
-      EOF
-    }
-
-    let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(with_tag))
-    }
-
-    it "should have the tag as revision" do
-      expect(repo.rev).to eq("refs/tags/v1.0.0")
-    end
-  end
-
-  context "only URL" do
-    let(:only_url) {
+  context "git without revision" do
+    let(:without_revision) {
       <<-EOF
       git: https://github.com/example/repo.git
       EOF
     }
 
-    let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(only_url))
-    }
-
-    it "should have nil as revision" do
-      expect(repo.rev).to be_nil
-    end
-  end
-
-  context "different commit" do
-    let(:different_commit) {
-      <<-EOF
-      git: https://github.com/example/repo.git
-      version: 0.1.0+git.commit.1234567890abcdef1234567890abcdef12345678
-      EOF
+    let(:shard) {
+      Crystal2Nix::Shard.from_yaml(without_revision)
     }
 
     let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(different_commit))
+      Crystal2Nix::Repo.new(shard.url, shard.rev, shard.type)
     }
 
-    it "should have the correct commit as revision" do
-      expect(repo.rev).to eq("1234567890abcdef1234567890abcdef12345678")
-    end
-  end
-
-  context "version with prefix" do
-    let(:version_with_prefix) {
-      <<-EOF
-      git: https://github.com/example/repo.git
-      version: v2.0.0
-      EOF
-    }
-
-    let(:repo) {
-      Crystal2Nix::Repo.new(Crystal2Nix::Shard.from_yaml(version_with_prefix))
-    }
-
-    it "should have the version as revision with the same prefix" do
-      expect(repo.rev).to eq("v2.0.0")
+    it "should have the correct url" do
+      expect(repo.url).to eq("https://github.com/example/repo.git")
     end
   end
 end

--- a/src/repo.cr
+++ b/src/repo.cr
@@ -1,19 +1,13 @@
 module Crystal2Nix
   class Repo
-    @url : URI
-    getter rev : String
+    property url : String
+    property rev : String?
+    property type : Symbol
 
-    def initialize(entry : Shard)
-      @url = URI.parse(entry.git).normalize
-      @rev = if entry.version =~ /^(?<version>.+)\+git\.commit\.(?<rev>.+)$/
-               $~["rev"]
-             else
-               "v#{entry.version}"
-             end
-    end
-
-    def url : String
-      @url.to_s
+    def initialize(url : String, rev : String? = nil, type : Symbol = :git)
+      @url = url
+      @rev = rev
+      @type = type
     end
   end
 end

--- a/src/shard.cr
+++ b/src/shard.cr
@@ -1,0 +1,19 @@
+module Crystal2Nix
+    class Shard
+      getter url : String
+      getter rev : String?
+      getter type : Symbol
+  
+      def self.from_yaml(yaml : String)
+        data = YAML.parse(yaml).as_h
+        url = data["git"]? || data["http"]?
+        rev = data["version"]?
+        type = data.has_key?("git") ? :git : :http
+        new(url, rev, type)
+      end
+  
+      def initialize(@url : String, @rev : String? = nil, @type : Symbol = :git)
+      end
+    end
+  end
+  

--- a/src/worker.cr
+++ b/src/worker.cr
@@ -7,31 +7,45 @@ module Crystal2Nix
 
     def run
       File.open SHARDS_NIX, "w+" do |file|
-        file.puts %({)
+        file.puts "{"
         ShardLock.from_yaml(File.read(@lock_file)).shards.each do |key, value|
-          repo = Repo.new value
+          repo = Repo.new value["url"], value["rev"], value["type"].to_sym
           if repo.nil?
             STDERR.puts "Unable to parse repository entry"
             exit 1
           end
           sha256 = ""
-          args = [
-            "--no-deepClone",
-            "--url", repo.url,
-            "--rev", repo.rev,
-          ]
-          Process.run("nix-prefetch-git", args: args) do |x|
-            x.error.each_line { |e| puts e }
-            sha256 = PrefetchJSON.from_json(x.output).sha256
+          case repo.type
+          when :git
+            args = [
+              "--no-deepClone",
+              "--url", repo.url,
+              "--rev", repo.rev,
+            ]
+            Process.run("nix-prefetch-git", args: args) do |x|
+              x.error.each_line { |e| puts e }
+              sha256 = PrefetchJSON.from_json(x.output).sha256
+            end
+          when :http
+            args = [
+              "--url", repo.url
+            ]
+            Process.run("nix-prefetch-url", args: args) do |x|
+              x.error.each_line { |e| puts e }
+              sha256 = x.output.strip
+            end
+          else
+            STDERR.puts "Unsupported repository type: #{repo.type}"
+            exit 1
           end
 
-          file.puts %(  #{key} = {)
-          file.puts %(    url = "#{repo.url}";)
-          file.puts %(    rev = "#{repo.rev}";)
-          file.puts %(    sha256 = "#{sha256}";)
-          file.puts %(  };)
+          file.puts "  #{key} = {"
+          file.puts "    url = \"#{repo.url}\";"
+          file.puts "    rev = \"#{repo.rev}\";" if repo.rev
+          file.puts "    sha256 = \"#{sha256}\";"
+          file.puts "  };"
         end
-        file.puts %(})
+        file.puts "}"
       end
     end
   end


### PR DESCRIPTION
Repo Class:

The Repo class now includes a type property, which can be :git or :http.
Worker Class:

In the run method, the repository type is checked.
If the type is :git, it runs nix-prefetch-git to fetch the repository's hash.
If the type is :http, it runs nix-prefetch-url to fetch the URL's hash.
It writes the repository information into the shards.nix file, including the URL, revision (if applicable), and the sha256 hash.