### PR TITLE
 use nix-prefetch-hg to handle the mercurial case

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -8,3 +8,6 @@ shards:
     git: https://github.com/hugopl/version_from_shard.git
     version: 1.2.5
 
+  carbon_smtp_adapter:
+    hg: https://hg.sr.ht/~peterhoeg/dummy
+    version: 0.1.1+hg.commit.4048cd7e156f3d4317e10ebd4e742020c8049310

--- a/shard.yml
+++ b/shard.yml
@@ -22,3 +22,8 @@ development_dependencies:
   spectator:
     gitlab: arctic-fox/spectator
     version: ~> 0.10.5
+
+dependencies:
+  carbon_smtp_adapter:
+    hg: https://hg.sr.ht/~peterhoeg/dummy
+    version: ~> 0.1.1

--- a/shards.nix
+++ b/shards.nix
@@ -9,4 +9,14 @@
     rev = "v1.2.5";
     sha256 = "0xizj0q4rd541rwjbx04cjifc2gfx4l5v6q2y7gmd0ndjmkgb8ik";
   };
+  carbon_smtp_adapter = {
+    hg = "https://hg.sr.ht/~peterhoeg/dummy";
+    rev = "v0.1.1";
+    sha256 = "0kdb0k1xzl4yysfmlif7xmr2mnb3y5f3knqr8dy08f3sq9n31x4z";
+
+  }
+
 }
+
+    
+   

--- a/src/runner.cr
+++ b/src/runner.cr
@@ -1,4 +1,0 @@
-require "./crystal2nix"
-require "./cli"
-
-Crystal2Nix::Cli.new.run

--- a/src/worker.cr
+++ b/src/worker.cr
@@ -7,45 +7,50 @@ module Crystal2Nix
 
     def run
       File.open SHARDS_NIX, "w+" do |file|
-        file.puts "{"
+        file.puts %({)
         ShardLock.from_yaml(File.read(@lock_file)).shards.each do |key, value|
-          repo = Repo.new value["url"], value["rev"], value["type"].to_sym
+          repo = Repo.new value
           if repo.nil?
             STDERR.puts "Unable to parse repository entry"
             exit 1
           end
           sha256 = ""
-          case repo.type
-          when :git
-            args = [
-              "--no-deepClone",
-              "--url", repo.url,
-              "--rev", repo.rev,
-            ]
-            Process.run("nix-prefetch-git", args: args) do |x|
-              x.error.each_line { |e| puts e }
-              sha256 = PrefetchJSON.from_json(x.output).sha256
-            end
-          when :http
-            args = [
-              "--url", repo.url
-            ]
-            Process.run("nix-prefetch-url", args: args) do |x|
-              x.error.each_line { |e| puts e }
-              sha256 = x.output.strip
-            end
-          else
-            STDERR.puts "Unsupported repository type: #{repo.type}"
-            exit 1
+          case 
+          when repo.url.ends_with?(".git")
+          
+          args = [
+            "--no-deepClone",
+            "--url", repo.url,
+            "--rev", repo.rev,
+          ]
+          Process.run("nix-prefetch-git", args: args) do |x|
+            x.error.each_line { |e| puts e }
+            sha256 = PrefetchJSON.from_json(x.output).sha256
           end
-
-          file.puts "  #{key} = {"
-          file.puts "    url = \"#{repo.url}\";"
-          file.puts "    rev = \"#{repo.rev}\";" if repo.rev
-          file.puts "    sha256 = \"#{sha256}\";"
-          file.puts "  };"
+        when repo.url.starts_with?("hg://") || repo.url.ends_with?(".hg")
+          args = [
+            "--url", repo.url,
+            "--rev", repo.rev,
+          ]
+          Process.run("nix-prefetch-hg", args: args) do |x|
+            x.error.each_line { |e| puts e }
+            sha256 = PrefetchJSON.from_json(x.output).sha256
+          end
+        when repo.url.ends_with?(".fossil")
+          STDERR.puts "Fossil repositories are not supported."
+          next
+        else
+          STDERR.puts "Unknown repository type for #{repo.url}"
+          next
         end
-        file.puts "}"
+
+          file.puts %(  #{key} = {)
+          file.puts %(    url = "#{repo.url}";)
+          file.puts %(    rev = "#{repo.rev}";)
+          file.puts %(    sha256 = "#{sha256}";)
+          file.puts %(  };)
+        end
+        file.puts %(})
       end
     end
   end


### PR DESCRIPTION
 Task achieved 
 
- crystal2nix should not blow up when running with unknown sources
 - use nix-prefetch-hg to handle the mercurial case
 - for fossil, I think we should just show a nice error that it isn't currently supported